### PR TITLE
Fix Docker issues

### DIFF
--- a/development/db/Dockerfile
+++ b/development/db/Dockerfile
@@ -2,3 +2,6 @@ FROM postgres:12-alpine
 
 COPY ./create_users.sh   /docker-entrypoint-initdb.d/10-create_users.sh
 COPY ./create_dbs.sh     /docker-entrypoint-initdb.d/20-create_dbs.sh
+
+RUN sed -i -e 's/\r$//' /docker-entrypoint-initdb.d/10-create_users.sh && \
+    sed -i -e 's/\r$//' /docker-entrypoint-initdb.d/20-create_dbs.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   db:
     build: development/db
     ports:
-      - "5432:5432"
+      - "15432:5432"
     environment:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=admin

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ security.jwt.expiration-in-ms = 864000000
 
 # We expect database called "bep2-huland-casino",
 # with the same username and password
-spring.datasource.url=jdbc:postgresql://localhost:5432/bep2-huland-casino
+spring.datasource.url=jdbc:postgresql://localhost:15432/bep2-huland-casino
 spring.datasource.username=bep2-huland-casino
 spring.datasource.password=bep2-huland-casino
 


### PR DESCRIPTION
This pull request fixes the CRLF issue on Windows.

```
/docker-entrypoint-initdb.d/10-create_users.sh: /bin/bash^M: bad interpreter: No such file or directory
```

I have also added a commit that changes the default PostgreSQL port, because almost all students have a PostgreSQL installed on Windows for another course that runs 24/7 as a service. Docker does not complain about the port already being in use for some reason. This should make it easier for some.

```
org.postgresql.util.PSQLException: FATAL: password authentication failed for user "bep2-huland-casino"
```

**Important to note**

Students that have already tried to run `docker-compose up` with the failing bash scripts will need to run `docker-compose up --build -V` once. To rebuild the docker image and **to wipe the volume data**, because otherwise the initdb scripts won't be executed again. Which have never ran because they failed "silently".

Feel free to edit / cherrypick etc..